### PR TITLE
Support rails 8.0.0 (#260)

### DIFF
--- a/.github/workflows/active-record-multi-tenant-tests.yml
+++ b/.github/workflows/active-record-multi-tenant-tests.yml
@@ -54,11 +54,13 @@ jobs:
           - rails-7.0
           - rails-7.1
           - rails-7.2
+          - rails-8.0
           - active-record-6.0
           - active-record-6.1
           - active-record-7.0
           - active-record-7.1
           - active-record-7.2
+          - active-record-8.0
         citus_version:
           - '10'
           - '11'

--- a/Appraisals
+++ b/Appraisals
@@ -20,6 +20,10 @@ appraise 'rails-7.2' do
   gem 'rails', '~> 7.2.0'
 end
 
+appraise 'rails-8.0' do
+  gem 'rails', '~> 8.0.0'
+end
+
 appraise 'active-record-6.0' do
   gem 'activerecord', '~> 6.0.3'
 end
@@ -38,4 +42,8 @@ end
 
 appraise 'active-record-7.2' do
   gem 'activerecord', '~> 7.2.0'
+end
+
+appraise 'active-record-8.0' do
+  gem 'activerecord', '~> 8.0.0'
 end

--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -66,8 +66,11 @@ module MultiTenant
 
         # Create an implicit belongs_to association only if tenant class exists
         if MultiTenant.tenant_klass_defined?(tenant_name, options)
-          belongs_to tenant_name, **options.slice(:class_name, :inverse_of, :optional)
-                                           .merge(foreign_key: options[:partition_key])
+          belongs_to(
+            tenant_name,
+            **options.slice(:class_name, :inverse_of, :optional),
+            foreign_key: options[:partition_key]
+          )
         end
 
         # New instances should have the tenant set

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -375,7 +375,7 @@ require 'active_record/relation'
 ActiveRecord::QueryMethods.prepend(MultiTenant::QueryMethodsExtensions)
 
 module MultiTenantFindBy
-  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 2
+  if ActiveRecord.gem_version >= Gem::Version.create('7.2.0')
     def cached_find_by_statement(connection, key, &block)
       return super unless respond_to?(:scoped_by_tenant?) && scoped_by_tenant?
 

--- a/lib/activerecord-multi-tenant/relation_extension.rb
+++ b/lib/activerecord-multi-tenant/relation_extension.rb
@@ -21,7 +21,7 @@ module Arel
 
       stmt = Arel::UpdateManager.new
       stmt.table(table)
-      stmt.set Arel.sql(@klass.send(:sanitize_sql_for_assignment, updates))
+      stmt.set Arel.sql(klass.send(:sanitize_sql_for_assignment, updates))
       stmt.wheres = [generate_in_condition_subquery]
 
       klass.connection.update(stmt, "#{klass} Update All").tap { reset }
@@ -39,7 +39,7 @@ module Arel
       # Build an Arel query
       arel = if eager_loading?
                apply_join_dependency.arel
-             elsif ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 2
+             elsif ActiveRecord.gem_version >= Gem::Version.create('7.2.0')
                build_arel(klass.connection)
              else
                build_arel

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -132,7 +132,7 @@ describe MultiTenant do
   end
 
   describe 'inspect method filters senstive column values' do
-    if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 2
+    if ActiveRecord.gem_version >= Gem::Version.create('7.2.0')
       # related: https://github.com/rails/rails/pull/49765
       around do |example|
         prev = Account.attributes_for_inspect


### PR DESCRIPTION
* Support rails 8.0.0

* fix rubocop warning

```
lib/activerecord-multi-tenant/model_extensions.rb:69:37: C: [Corrected] Style/KeywordArgumentsMerging: Provide additional arguments directly rather than using merge.
          belongs_to tenant_name, **options.slice(:class_name, :inverse_of, :optional) ...
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```